### PR TITLE
Feature: wait_for_single_service timeout

### DIFF
--- a/src/g3pylib/__init__.py
+++ b/src/g3pylib/__init__.py
@@ -201,12 +201,12 @@ class connect_to_glasses:
 
     @staticmethod
     async def _urls_from_zeroconf(
-        using_ip: bool, timeout: float = 3
+        using_ip: bool, timeout: float
     ) -> Tuple[str, Optional[str]]:
         async with G3ServiceDiscovery.listen() as service_discovery:
             service = await service_discovery.wait_for_single_service(
                 service_discovery.events,
-                timeout=timeout,
+                timeout,
             )
         return await connect_to_glasses._urls_from_service(service, using_ip)
 
@@ -240,7 +240,7 @@ class connect_to_glasses:
         If `using_ip` is set to True (default) we will generate the the URL used for connection with the ip.
         If it's set to False we will use the hostname, which will depend on DNS working as it should.
 
-        `timeout` defines the time in seconds before `asyncio.TimeoutError` is raised."""
+        `timeout` defines the time in milliseconds before `asyncio.TimeoutError` is raised."""
         return cls(cls._urls_from_zeroconf(using_ip, timeout))
 
     @classmethod

--- a/src/g3pylib/__init__.py
+++ b/src/g3pylib/__init__.py
@@ -231,7 +231,7 @@ class connect_to_glasses:
 
     @classmethod
     def with_zeroconf(
-        cls, using_ip: bool = True, timeout: float = 3
+        cls, using_ip: bool = True, timeout: float = 3000
     ) -> connect_to_glasses:
         """Connects by listening for available glasses on the network using zeroconf.
         Connects to the first pair of glasses that answers so if there are multiple glasses on the

--- a/src/g3pylib/__init__.py
+++ b/src/g3pylib/__init__.py
@@ -200,10 +200,13 @@ class connect_to_glasses:
         self.url_generator = url_generator
 
     @staticmethod
-    async def _urls_from_zeroconf(using_ip: bool) -> Tuple[str, Optional[str]]:
+    async def _urls_from_zeroconf(
+        using_ip: bool, timeout: float = 3
+    ) -> Tuple[str, Optional[str]]:
         async with G3ServiceDiscovery.listen() as service_discovery:
             service = await service_discovery.wait_for_single_service(
-                service_discovery.events
+                service_discovery.events,
+                timeout=timeout,
             )
         return await connect_to_glasses._urls_from_service(service, using_ip)
 
@@ -227,14 +230,18 @@ class connect_to_glasses:
             return await connect_to_glasses._urls_from_service(service, using_ip)
 
     @classmethod
-    def with_zeroconf(cls, using_ip: bool = True) -> connect_to_glasses:
+    def with_zeroconf(
+        cls, using_ip: bool = True, timeout: float = 3
+    ) -> connect_to_glasses:
         """Connects by listening for available glasses on the network using zeroconf.
         Connects to the first pair of glasses that answers so if there are multiple glasses on the
         network the behavior is undefined.
 
         If `using_ip` is set to True (default) we will generate the the URL used for connection with the ip.
-        If it's set to False we will use the hostname, which will depend on DNS working as it should."""
-        return cls(cls._urls_from_zeroconf(using_ip))
+        If it's set to False we will use the hostname, which will depend on DNS working as it should.
+
+        `timeout` defines the time in seconds before `asyncio.TimeoutError` is raised."""
+        return cls(cls._urls_from_zeroconf(using_ip, timeout))
 
     @classmethod
     def with_hostname(

--- a/src/g3pylib/zeroconf.py
+++ b/src/g3pylib/zeroconf.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import time
 from contextlib import asynccontextmanager
 from enum import Enum, auto
 from types import TracebackType
@@ -325,25 +326,31 @@ class G3ServiceDiscovery:
     async def wait_for_single_service(
         events: asyncio.Queue[Tuple[EventKind, G3Service]],
         ip_version: IPVersion = IPVersion.All,
-        timeout: int = 3,
+        timeout: float = 3,
     ) -> G3Service:
         """Returns the first available `G3Service`.
 
-        Continuously reads from `events` until a `G3Service` is available. The service is then returned.
+        `events` is the `G3DiscoveryService.events` queue used to look for service events.
+        `ip_version` specifies what type(s) of ip address are required in the returned service.
+        `timeout` defines the time in seconds before `asyncio.TimeoutError` is raised.
 
         Must be called in the `listen` context to find a service.
         """
+        t_start = time.time()
+        t_done = t_start + timeout
         while True:
-            event = await asyncio.wait_for(events.get(), timeout=timeout)
-            if event[0] in [EventKind.UPDATED, EventKind.ADDED]:
-                service = event[1]
-                match ip_version:
-                    case IPVersion.All:
-                        if service.ipv4_address and service.ipv6_address:
-                            return service
-                    case IPVersion.V4Only:
-                        if service.ipv4_address:
-                            return service
-                    case IPVersion.V6Only:
-                        if service.ipv6_address:
-                            return service
+            time_left = t_done - time.time()
+            if time_left > 0:
+                event = await asyncio.wait_for(events.get(), timeout=time_left)
+                if event[0] in [EventKind.UPDATED, EventKind.ADDED]:
+                    service = event[1]
+                    match ip_version:
+                        case IPVersion.All:
+                            if service.ipv4_address and service.ipv6_address:
+                                return service
+                        case IPVersion.V4Only:
+                            if service.ipv4_address:
+                                return service
+                        case IPVersion.V6Only:
+                            if service.ipv6_address:
+                                return service

--- a/src/g3pylib/zeroconf.py
+++ b/src/g3pylib/zeroconf.py
@@ -325,6 +325,7 @@ class G3ServiceDiscovery:
     async def wait_for_single_service(
         events: asyncio.Queue[Tuple[EventKind, G3Service]],
         ip_version: IPVersion = IPVersion.All,
+        timeout: int = 3,
     ) -> G3Service:
         """Returns the first available `G3Service`.
 
@@ -333,7 +334,7 @@ class G3ServiceDiscovery:
         Must be called in the `listen` context to find a service.
         """
         while True:
-            event = await events.get()
+            event = await asyncio.wait_for(events.get(), timeout=timeout)
             if event[0] in [EventKind.UPDATED, EventKind.ADDED]:
                 service = event[1]
                 match ip_version:

--- a/src/g3pylib/zeroconf.py
+++ b/src/g3pylib/zeroconf.py
@@ -325,19 +325,19 @@ class G3ServiceDiscovery:
     @staticmethod
     async def wait_for_single_service(
         events: asyncio.Queue[Tuple[EventKind, G3Service]],
+        timeout: float,
         ip_version: IPVersion = IPVersion.All,
-        timeout: float = 3,
     ) -> G3Service:
         """Returns the first available `G3Service`.
 
         `events` is the `G3DiscoveryService.events` queue used to look for service events.
         `ip_version` specifies what type(s) of ip address are required in the returned service.
-        `timeout` defines the time in seconds before `asyncio.TimeoutError` is raised.
+        `timeout` defines the time in milliseconds before `asyncio.TimeoutError` is raised.
 
         Must be called in the `listen` context to find a service.
         """
         t_start = time.time()
-        t_done = t_start + timeout
+        t_done = t_start + timeout / 1000
         while True:
             time_left = t_done - time.time()
             if time_left > 0:

--- a/src/g3pylib/zeroconf.py
+++ b/src/g3pylib/zeroconf.py
@@ -325,7 +325,7 @@ class G3ServiceDiscovery:
     @staticmethod
     async def wait_for_single_service(
         events: asyncio.Queue[Tuple[EventKind, G3Service]],
-        timeout: float,
+        timeout: float = 3000,
         ip_version: IPVersion = IPVersion.All,
     ) -> G3Service:
         """Returns the first available `G3Service`.

--- a/tests/test_connect_to_glasses.py
+++ b/tests/test_connect_to_glasses.py
@@ -57,9 +57,3 @@ async def test_connect_with_urls(g3_hostname: str):
     ) as g3:
         serial = await g3.system.get_recording_unit_serial()
         assert type(serial) is str
-
-
-async def test_connect_with_zeroconf():
-    async with connect_to_glasses.with_zeroconf() as g3:
-        serial = await g3.system.get_recording_unit_serial()
-        assert type(serial) is str

--- a/tests/test_connect_to_glasses.py
+++ b/tests/test_connect_to_glasses.py
@@ -57,3 +57,9 @@ async def test_connect_with_urls(g3_hostname: str):
     ) as g3:
         serial = await g3.system.get_recording_unit_serial()
         assert type(serial) is str
+
+
+async def test_connect_with_zeroconf():
+    async with connect_to_glasses.with_zeroconf() as g3:
+        serial = await g3.system.get_recording_unit_serial()
+        assert type(serial) is str


### PR DESCRIPTION
Note that timeout is implemented cumulatively over the discovery events using the time module. 

with_zeroconf and _urls_from_zeroconf now also take a timeout parameter.

A test for with_zeroconf was added.

Resolves #63 