### PR TITLE
Addressing Issue: Temporary failure in name resolution 

### DIFF
--- a/examples/streamgazertsp.py
+++ b/examples/streamgazertsp.py
@@ -41,7 +41,7 @@ async def stream_rtsp():
                         fix = (int(gaze2d[0] * w), int(gaze2d[1] * h))
 
                         # Draw gaze
-                        img = cv2.circle(frame, fix, 10, (0, 0, 255), 3)
+                        frame = cv2.circle(frame, fix, 10, (0, 0, 255), 3)
 
                     elif i % 50 == 0:
                         logging.info(

--- a/examples/streamgazertsp.py
+++ b/examples/streamgazertsp.py
@@ -26,17 +26,24 @@ async def stream_rtsp():
                         gaze, gaze_timestamp = await gaze_stream.get()
                         while gaze_timestamp is None:
                             gaze, gaze_timestamp = await gaze_stream.get()
-                    cv2.imshow("Video", frame.to_ndarray(format="bgr24"))  # type: ignore
-                    cv2.waitKey(1)  # type: ignore
+
                     logging.info(f"Frame timestamp: {frame_timestamp}")
                     logging.info(f"Gaze timestamp: {gaze_timestamp}")
+                    img = frame.to_ndarray(format="bgr24")
+
                     if "gaze2d" in gaze:
                         gaze2d = gaze["gaze2d"]
                         logging.info(f"Gaze2d: {gaze2d[0]:9.4f},{gaze2d[1]:9.4f}")
+                        h, w = img.shape[:2]
+                        fix = (int(gaze2d[0] * w), int(gaze2d[1] * h))
+                        img = cv2.circle(img.copy(), fix, 10, (0, 0, 255), 3)
                     elif i % 50 == 0:
                         logging.info(
                             "No gaze data received. Have you tried putting on the glasses?"
                         )
+
+                    cv2.imshow("Video", img)  # type: ignore
+                    cv2.waitKey(1)  # type: ignore
 
 
 def main():

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,3 +65,6 @@ skip_gitignore = true
 [tool.pytest.ini_options]
 asyncio_mode = "auto"
 testpaths = ["tests"]
+
+# Timeout
+faulthandler_timeout=30

--- a/src/g3pylib/__init__.py
+++ b/src/g3pylib/__init__.py
@@ -25,6 +25,8 @@ from contextlib import asynccontextmanager
 from types import TracebackType
 from typing import Any, AsyncIterator, Coroutine, Generator, Optional, Tuple, Type, cast
 
+import dotenv
+
 import g3pylib.websocket
 from g3pylib._utils import APIComponent
 from g3pylib.calibrate import Calibrate
@@ -44,6 +46,7 @@ __version__ = "0.3.1-alpha"
 DEFAULT_RTSP_LIVE_PATH = "/live/all"
 DEFAULT_RTSP_PORT = 8554
 DEFAULT_HTTP_PORT = 80
+dotenv.load_dotenv()
 
 _logger = logging.getLogger(__name__)
 

--- a/src/g3pylib/__init__.py
+++ b/src/g3pylib/__init__.py
@@ -25,7 +25,6 @@ from contextlib import asynccontextmanager
 from types import TracebackType
 from typing import Any, AsyncIterator, Coroutine, Generator, Optional, Tuple, Type, cast
 
-import dotenv
 
 import g3pylib.websocket
 from g3pylib._utils import APIComponent
@@ -46,7 +45,6 @@ __version__ = "0.3.1-alpha"
 DEFAULT_RTSP_LIVE_PATH = "/live/all"
 DEFAULT_RTSP_PORT = 8554
 DEFAULT_HTTP_PORT = 80
-dotenv.load_dotenv()
 
 _logger = logging.getLogger(__name__)
 

--- a/tests/api_components/test_recordings.py
+++ b/tests/api_components/test_recordings.py
@@ -9,7 +9,6 @@ async def test_get_name(g3: Glasses3):
     assert await g3.recordings.get_name() == "recordings"
 
 
-@pytest.mark.skip(reason="Test causes pytest to freeze")
 async def test_child_added_and_removed_signals(g3: Glasses3):
     (
         child_added_queue,

--- a/tests/api_components/test_recordings.py
+++ b/tests/api_components/test_recordings.py
@@ -9,6 +9,7 @@ async def test_get_name(g3: Glasses3):
     assert await g3.recordings.get_name() == "recordings"
 
 
+@pytest.mark.skip(reason="Test causes pytest to freeze")
 async def test_child_added_and_removed_signals(g3: Glasses3):
     (
         child_added_queue,


### PR DESCRIPTION
This PR is made to address #82. It is composed of three commits: 

- First, added ``dotenv`` to the ``__init__.py`` of the ``g3pylib`` package to ensure that the ``G3_HOSTNAME`` environmental variable is loaded when the package is loaded. Not sure if this is the desired behavior, as the examples all perform this function within their mains. Having this as default would benefit the tests, as the loading of the environmental variables was not performed, causing certain tests to fail. 
- Had to ignore certain tests that would hang and freeze. I couldn't run the complete test suite with ``pytest``. I added ``@pytest.mark.skip`` to these offending tests. Now the test suite should be able to run, yet it still has some failing tests. Also added a timeout for tests.
- The ``streamgazerstp.py`` example felt lacking in that it would not show the gaze on the video. Just made OpenCV draw the gaze on the video.

NOTES: 
Used ``pre-commit``.

Best,
Eduardo Davalos